### PR TITLE
Revisions to security document

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -15,25 +15,25 @@ keywords:
 ---
 
 
-»We take security very serious.« Isn't that what everybody is saying? It's our business to keep your business online. Our clients trust us with that. We know what we do and we are doing hosting for over ten years now. Make yourself a picture, have a look at our: [history](http://www.fortrabbit.com/about), [blog](http://blog.fortrabbit.com/), [tweets](https://twitter.com/fortrabbit), [past incidents](http://status.fortrabbit.com) or ask our customers directly.
+»We take security very seriously.« Isn't that what everybody is saying? It's our business to keep your business online. Our clients trust us with that. We know what we do and we have been doing hosting for over ten years now. To help paint a picture of our experience, have a look at our: [history](http://www.fortrabbit.com/about), [blog](http://blog.fortrabbit.com/), [tweets](https://twitter.com/fortrabbit), [past incidents](http://status.fortrabbit.com) or ask our customers directly.
 
 ## Our responsibilities
 
 ### Physical infrastructure
 
-fortrabbit utilizes Amazon Web Service (AWS) data centers. Amazon data centers have been accredited under several certificates (including ISO 27001). AWS stands for a high level of physical security to safeguard their data centers. Among others things they employ two-factor authentication for all their authorized staff members, military grade perimeter controls and security staff at all ingress points.
+fortrabbit utilizes Amazon Web Services (AWS) data centers. Amazon data centers are compliant with and certified under a number of security standards, including ISO 27001. AWS enforces a high level of physical security to safeguard their data centers. Among other features, they enforce two-factor authentication for all their authorized staff members, military grade perimeter controls and security staff at all points of ingress.
 
-As for environmental protection AWS has sophisticated fire detection and suppression equipment, fully redundant power infrastructure with integrated UPS units and high end climate control system to guarantee an optimal working environment for the hardware.
+As for environmental protection, AWS has sophisticated fire detection and suppression equipment, fully redundant power infrastructure with integrated UPS units and high-end climate control systems to guarantee an optimal working environment for the hardware.
 
-For a more in detail view, we refer you to the [AWS Security Center](https://aws.amazon.com/security).
+For a more in-depth view, we refer you to the [AWS Security Center](https://aws.amazon.com/security).
 
 ### SysOp level
 
-fortrabbit employs a multi tier security strategy.
+fortrabbit employs a multi-tier security strategy.
 
-On the inside, each node is build around a hardened Linux kernel, which enforces strong privilege and resource separation mechanisms on OS level. All operating systems and software components are kept up-to-date and by our maintenance staff and we pride ourselves in reacting fast to all [Poodles](http://blog.fortrabbit.com/ssl-v3-disabled-poodle-vulnerability/), [Heartbleeds](http://blog.fortrabbit.com/heartbleed-openssl-vulnerability/), Shellshocks and [Ghosts](https://twitter.com/fortrabbit/status/560478509475577856) that have and will come up.
+On the inside, each node is built around a hardened Linux kernel, which enforces strong privilege and resource separation mechanisms at an OS level. All operating systems and software components are kept up-to-date by our maintenance staff and we pride ourselves in reacting quickly to all [Poodles](http://blog.fortrabbit.com/ssl-v3-disabled-poodle-vulnerability/), [Heartbleeds](http://blog.fortrabbit.com/heartbleed-openssl-vulnerability/), Shellshocks and [Ghosts](https://twitter.com/fortrabbit/status/560478509475577856) that have and will come up.
 
-The next tier are isolated virtual containers, which guarantee complete logical separation of Apps on fortrabbit. In addition, the container technology allows for hard resource capping reducing the bad neighbor effect of shared environments to a bare minimum.
+At the next tier, each node exists within isolated virtual containers, which guarantee complete logical separation of Apps on fortrabbit. In addition, the container technology allows for hard resource capping, which reduces the bad neighbor effect of shared environments to a bare minimum.
 
 On the outside, we utilize network firewalling and hardened TCP/IP stacks to mitigate resource exhaustion attempts. Sniffing and spoofing attacks are prevented through the underlying infrastructure. Our setup is flexible and we are able to isolate or boost resources quickly.
 
@@ -43,57 +43,47 @@ We use Wirecard — a PCI Level 1 compliant provider — for processing credit c
 
 ## Your responsibilities
 
-We are in it together! You are responsible for the code you write and even the one you are using.
+We are in it together! You are responsible for the code you write and use.
 
 ### Check your code
 
-Make sure to follow [security guidelines](http://www.phptherightway.com/#security). It's a good practice to perform a security check against the most common attack vectors before going live. Also mind the [OWASP Cheat Sheets](https://www.owasp.org/index.php/OWASP_Cheat_Sheet_Series) to negate attacks before they can start.
+Make sure to follow [security guidelines](http://www.phptherightway.com/#security). It's good practice to perform a security check against the most common attack vectors before going live. Also mind the [OWASP Cheat Sheets](https://www.owasp.org/index.php/OWASP_Cheat_Sheet_Series) to negate attacks before they can start.
 
 ### Frameworks & CMS systems
 
-Update the frameworks and CMS systems frequently. You are to blame when your WordPress installation becomes out of date and gets hacked. Composer makes updating easy for modern frameworks.
+Frequently update the frameworks and CMSs you use. When security vulnerabilities are discovered and patched, it is your responsibility to stay up-to-date. Having an outdated WordPress installation puts your site at great risk of being hacked. Composer makes updating easy for modern frameworks.
 
 ## Dashboard access
 
-The password you use to login with the [fortrabbit Dashboard](https://dashboard.fortrabbit.com) is your master password. We recommend to use a [pass-phrase](http://xkcd.com/936/) kind of password. Use something that is easy to remember for you, but hard to guess for anyone else while long enough to stand against brute force attacks.
+The password you use to login with the [fortrabbit Dashboard](https://dashboard.fortrabbit.com) is your master password. We recommend using a [pass-phrase](http://xkcd.com/936/) kind of password. Use something that is easy to remember for you, but hard for anyone else to guess and long enough to stand against brute force attacks.
+
+### Two-factor authentication
+
+We highly recommend enabling two-factor authentication (2FA) with your fortrabbit Account. You can so do in the Dashboard — you'll be guided setting it up. Our 2FA is a software implementation, which means that you'll need an extra device such as a smart phone and an extra 2FA software to generate your TOTP (time-based one time passwords).
 
 ### Session time
 
-It's always a balance between usability and security. Per default we'll log you out after some time of inactivity. You can modify that timing in the Dashboard under your Account settings.
-
-### Account password
-
-Please choose a secure fortrabbit Account password. The best password is hard to crack but easy to remember. Pass-phrases can work well here.
-
+It's always a balance between usability and security. By default we'll log you out after some time of inactivity. You can modify that timing in the Dashboard under your Account settings.
 
 ### Re-enter Account password for critical actions
 
 For "dangerous actions" in the Dashboard you need to re-authenticate with your Account password (and 2FA if enabled). As the fortrabbit [Dashboard](dashboard) is all about administrative tasks, this includes many tasks. So in short: we do [SUDO](http://en.wikipedia.org/wiki/Sudo). You can also modify how often you'll have to enter your SUDO password.
 
-### Two-factor authentication
-
-We highly recommend to enable 2FA with your fortrabbit Account. You can so do in the Dashboard — you'll be guided setting it up. Our 2FA is a software implementation, which means that you'll need an extra device such as a smart phone and an extra 2FA software to generate your TOTP (time-based one time passwords).
-
-
 ## Code access
 
-We recomend to store your [public SSH](/ssh-keys) key with your fortrabbit Account. You can also install multiple keys with your Account, for instance one for your desktop, one for your laptop. fortrabbit automatically installs your up-to-date key(s) on each App you have access to.
+We recommend storing your [public SSH](/ssh-keys) key with your fortrabbit Account. You can also install multiple keys with your Account. For instance, you could have two separate keys for your desktop and laptop. fortrabbit automatically installs your up-to-date key(s) on each App you have access to.
 
 ### Check your SSH keys
 
 Please revisit your list of SSH keys from time to time and keep it as short as possible. Only keep those keys you are really using.
 
-
 ### Password reset
 
 You can reset the fortrabbit service passwords for MySQL and Object Storage in the Dashboard with your Apps. It is recommended to reset those passwords periodically and when a Company member leaves for each App.
 
-
-
 ## Firewalling
 
-Per default all outgoing calls on all ports, except for [standard ones](https://www.fortrabbit.com/specs#firewall), are closed. You can request to white-list a port or port range. You do so in the Dashboard in the settings of your App.
-
+Per default all outgoing calls on all ports, except for [standard ones](https://www.fortrabbit.com/specs#firewall), are closed. You can request to whitelist a port or port range via the Dashboard in the settings of your App.
 
 ## Vulnerability reporting
 
@@ -101,8 +91,8 @@ Per default all outgoing calls on all ports, except for [standard ones](https://
 
 Bruce Schneier
 
-Do you have discovered a security issue related to fortrabbit? Please disclose in a responsible manner. We have high regard for white hat hacking culture and will work with you to understand the scope of the issue.
+Have you discovered a security issue related to fortrabbit? Please disclose it in a responsible manner. We have high regard for white hat hacking culture and will work with you to understand the scope of the issue.
 
-To report a possible security issue, please mail to: [security@fortrabbit.com](mailto:security@fortrabbit.com) using our [PGP key](/fortrabbit.pgp.asc).
+To report a possible security issue, please mail: [security@fortrabbit.com](mailto:security@fortrabbit.com) using our [PGP key](/fortrabbit.pgp.asc).
 
 **Thanks for keeping fortrabbit secure!**  Mayank Bhatodra, Salman Khan Champion [dezignburg.com](http://www.dezignburg.com), YOU?


### PR DESCRIPTION
This pull request fixes some grammatical errors and makes some wording changes to the `security` document to make its contents seem more natural.

I apologize for this being a bit lengthy, but I have included some thoughts and justification for some of the more significant changes.

- Wording: `Make yourself a picture,` -> `To help paint a picture of our experience`
	- More natural use of the idiom
	- Reinforces the focus on lengthy experience
- Restructure: `Amazon data centers have been accredited under several certificates (including ISO 27001).` -> `Amazon data centers are compliant with and certified under a number of security standards, including ISO 27001.`
	- ISO 27001 is the security standard, and Amazon is certified to be complaint with it, this wording may be more correct given the definitions at play here
	- Removed parenthetical statement
- Wording: `AWS stands for a` -> `AWS enforces a`
	- "stands for" sounds more like a definition
	- Better conveys that AWS uses these features
- Wording: `others things` -> `other features`
	- Reduces ambiguity
- Wording: `in detail` -> `in-depth`
	- Would go for "in-depth" or "detailed" but not "in detail"
	- "in-depth" feels more common, but that's also more a personal preference
- Restructure: `The next tier are isolated virtual containers` -> `At the next tier, each node exists within isolated virtual containers`
	- Follows structure of surrounding paragraphs, with introductory clauses
	- Resolves conflict between quantity of "tier" and "are"
- Wording: `hard resource capping reducing the bad neighbor effect` -> `hard resource capping, which reduces the bad neighbor effect`
	- Clause breakdown feels more natural
- Restructure: `You are responsible for the code you write and even the one you are using.` -> `You are responsible for the code you write and use.`
	- "and even" sounds more like something that would come after a list, but this only comes after one statement
	- Short and direct, but may be a little _too_ short with this adjustment
- Restructure: `Update the frameworks and CMS systems frequently. You are to blame when your WordPress installation becomes out of date and gets hacked. Composer makes updating easy for modern frameworks.` -> `Frequently update the frameworks and CMSs you use. When security vulnerabilities are discovered and patched, it is your responsibility to stay up-to-date. Having an outdated WordPress installation puts your site at great risk of being hacked. Composer makes updating easy for modern frameworks.`
	- This is a tough one. I agree with WordPress being such a headache from a security standpoint, but at the same time I feel the tone here is a bit on the strong side
	- Instead, this is a bit more neutral, and more general for all systems, but still tries to keep the original point about WordPress specifically
	- "CMS systems" is redundant
	- "frequently" being closer to "update" feels more natural, like it places more emphasis on the action. This is, again, a more personal preference
- Removed: `Account password` subsection, because its information is redundant, compared to the more detailed description within the `Dashboard access` section
- Restructure: Placed `Two-factor authentication` subsection at the top of its section
	- Introduce the `2FA` abbreviation before being used in the `Re-enter Account password for critical actions` section
	- Keep the information close to the password/authentication information
- Wording: `2FA` -> `two-factor authentication (2FA)`
	- Just to introduce the acronym similar to how it is in previous sections
	- Could also be placed in the subsection title instead
- Restructure: `You can also install multiple keys with your Account. for instance one for your desktop, one for your laptop.` -> `You can also install multiple keys with your Account. For instance, you could have two separate keys for your desktop and laptop.`
	- A little awkward sounding when so long
- Restructure: `You can request to white-list a port or port range. You do so in the Dashboard in the settings of your App.` -> `You can request to whitelist a port or port range via the Dashboard in the settings of your App.`
	- Repetition at the beginning of each sentence seemed a little awkward, condensed to one sentence instead
	- `white-list` -> `whitelist`
- spacing consistency between sections. Every section is now separated by only one blank line