### PR TITLE
Clarify how memory limits apply to Worker L+

### DIFF
--- a/docs/worker-pro.md
+++ b/docs/worker-pro.md
@@ -49,7 +49,7 @@ The Worker is an optional Component that can be booked and scaled from the [Apps
 
 In addition the CPU resources available scale linear with the amount of memory: a plan with 512 MB memory has access to four times the CPU time as a plan with 128 MB memory.
 
-The memory limit is for all jobs combined. For *Worker L* plans and above, there's also a default soft limit of 1024 MB memory per job to ensure there's enough for all concurrently running jobs - this can be overriden with `ini_set('memory_limit', xxxxM');` up to your Worker plan limit. The amount of configurable jobs is based on the average usage we have seen on our platform. Mind that resources needs for each application can vary largely, depending on what each particular job is doing. It is not unheard of for a single job to consume beyond 512 MB when doing extremely memory intensive tasks. In this case you need to select a plan accordingly.
+The memory limit is for all jobs combined. For *Worker L* plans and above, there's also a default soft limit of 1024 MB memory per job to ensure there's enough for all concurrently running jobs - this can be overriden with `ini_set('memory_limit', xxxxM');` up to your Worker plan limit. The number of configurable jobs is based on the average usage we have seen on our platform. Resources needed for each application can vary largely, depending on what each particular job is doing. It's not unheard of for a single job to consume beyond 512 MB when doing extremely memory intensive tasks. In this case you need to select a plan accordingly.
 
 * See the [specs page](http://www.fortrabbit.com/specs#worker) for limits.
 

--- a/docs/worker-pro.md
+++ b/docs/worker-pro.md
@@ -49,7 +49,7 @@ The Worker is an optional Component that can be booked and scaled from the [Apps
 
 In addition the CPU resources available scale linear with the amount of memory: a plan with 512 MB memory has access to four times the CPU time as a plan with 128 MB memory.
 
-The memory limit is for all jobs combined. The amount of configurable jobs is based on the average usage we have seen on our platform. Mind that resources needs for each application can vary largely, depending on what each particular job is doing. It is not unheard of for a single job to consume beyond 512 MB when doing extremely memory intensive tasks. In this case you need to select a plan accordingly.
+The memory limit is for all jobs combined. For *Worker L* plans and above, there's also a default soft limit of 1024 MB memory per job to ensure there's enough for all concurrently running jobs - this can be overriden with `ini_set('memory_limit', xxxxM');` up to your Worker plan limit. The amount of configurable jobs is based on the average usage we have seen on our platform. Mind that resources needs for each application can vary largely, depending on what each particular job is doing. It is not unheard of for a single job to consume beyond 512 MB when doing extremely memory intensive tasks. In this case you need to select a plan accordingly.
 
 * See the [specs page](http://www.fortrabbit.com/specs#worker) for limits.
 


### PR DESCRIPTION
This needs double checking by you guys, I only know for sure that a soft 1GB applies to Worker XXL which has a total of 4GB. Unsure whether the soft limit for Worker L/XL is fixed at 1GB too, as I guess a 25% rule could conceivably be in place?