### PR TITLE
Example to re-enable color escape sequences in worker log output

### DIFF
--- a/docs/logging-pro.md
+++ b/docs/logging-pro.md
@@ -63,7 +63,7 @@ $ ssh {{ssh-user}}@log.{{region}}.frbit.com tail source:web_stderr source:web_ph
 # Filter by HTTP status code, e.g. 4xx OR 3xx:
 $ ssh {{ssh-user}}@log.{{region}}.frbit.com tail source:apache_access 2>&1 | grep -E ' 40.?| 30.?'
 
-# Set terminal colors, if your worker output includes colors escape sequences, e.g. '#033[1;32m' to green:
+# Set terminal colors, if your worker output includes color escaped sequences, e.g. '#033[1;32m' to green:
 $ ssh {{ssh-user}}@log.{{region}}.frbit.com tail source:worker 2>&1 | sed 's/#033/\o033/g'
 ```
 

--- a/docs/logging-pro.md
+++ b/docs/logging-pro.md
@@ -60,8 +60,11 @@ $ ssh {{ssh-user}}@log.{{region}}.frbit.com tail {{app-name}} mono
 # Use multiple source:name parameters at once:
 $ ssh {{ssh-user}}@log.{{region}}.frbit.com tail source:web_stderr source:web_php_error
 
-# Filter by HTTP status code, e.g. 4xx OR 3xx
+# Filter by HTTP status code, e.g. 4xx OR 3xx:
 $ ssh {{ssh-user}}@log.{{region}}.frbit.com tail source:apache_access 2>&1 | grep -E ' 40.?| 30.?'
+
+# Set terminal colors, if your worker output includes colors escape sequences, e.g. '#033[1;32m' to green:
+$ ssh {{ssh-user}}@log.{{region}}.frbit.com tail source:worker 2>&1 | sed 's/#033/\o033/g'
 ```
 
 ## Quirks


### PR DESCRIPTION
In my worker log output I've many color escape sequences because of "colorization" .. it makes the output hard to understand at a glance.

e.g. 
```
2020-10-28T07:21:05Z INFO (my-app[172]): #033[1;36m[2020-10-28 08:21:05.201067] Progress: 22550#033[22;39m#033[0;49m
2020-10-28T07:21:05Z INFO (my-app[172]): #033[1;32m[2020-10-28 08:21:05.223125] Successfully updated article "xxxx"#033[22;39m#033[0;49m
```

With the proposed substitution,  the color sequences are "refreshed" for the client terminal to be displayed as color.
