### PR TITLE
Better feature Craft Copy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,5 +71,6 @@
     "wkhtmltopdf",
     "wordpress",
     "yourdomain"
-  ]
+  ],
+  "cSpell.language": "en"
 }

--- a/docs/craft-3-about.md
+++ b/docs/craft-3-about.md
@@ -33,44 +33,9 @@ There are [two hosting stacks](/stacks) here on fortrabbit. You can choose with 
 2. The [Professional Stack](/app-pro) is designed to scale horizontally. All components are redundant to assure high uptime. Use it for serious business + potentially large sites. 
 
 
-## Choose your workflow
-
-There are many ways to work with Craft CMS — depending on project needs and skills.
-
-### Modern workflow
-
-Experienced developers who are ready to work with a terminal, [Git](/git) and [Composer](/composer) will benefit most from our advanced workflows. This is where our 💜s are.
+## Workflow
 
 1. **[Install Craft CMS locally](craft-3-install-local)**: Install new with Composer or use an existing project
-2. **[Setup Craft for fortrabbit](/craft-3-setup)**: Prepare environments, sync database
-3. **[Deploy Craft with Git](/craft-3-deploy-git)**
-4. **Manage assets** for [Uni Apps](/craft-3-assets-uni) or [Pro Apps](/craft-3-assets-pro)
+2. **[Setup Craft for fortrabbit](/craft-3-setup)**: Prepare environment, set defaults
+3. **[Deploy Craft](/craft-3-deploy-craft-copy)**: Use our Craft Copy tool to deploy your Craft
 5. **[Tune Craft](/craft-3-tune)**: Master it!
-
-
-### Craft Copy
-
-**Take a shortcut!** We have published this little handy open-source command line tool to speed up common deployment tasks around Craft CMS on fortrabbit. It connects your local Craft CMS installation with an App on fortrabbit and then enables you to sync database and assets in a speedy and convenient way. It guides you through the process of setting everything up, and it even has a table to show you which parts are still missing. Give it a try! Here is an appetizer:
-
-```bash
-# Install and initialize
-$ composer config platform --unset
-$ composer require fortrabbit/craft-copy:^1.0.0-RC11
-$ ./craft plugin/install copy
-$ ./craft copy/setup
-
-# Sync database up (local ⟶ fortrabbit)
-$ php craft copy/db/up
-```
-
-Please head on to [github.com/fortrabbit/craft-copy](https://github.com/fortrabbit/craft-copy) for more details and usage examples.
-
-
-### Legacy workflow
-
-Developers focusing on front-end or web designers are likely more comfortable using the legacy SFTP workflow. Use this workflow when you are coming from WordPress or if you are not comfortable with a terminal, Git and Composer. This is your route:
-
-1. **[Install Craft CMS locally](craft-3-install-local)**: Install new with Composer or use an existing project
-2. **[Setup Craft for fortrabbit](/craft-3-setup)**: Prepare environments, sync database
-3. **[Upload Craft with SFTP](/craft-3-upload-sftp)**
-4. **[Tune Craft](/craft-3-tune)**: Master it!

--- a/docs/craft-3-about.md
+++ b/docs/craft-3-about.md
@@ -13,7 +13,7 @@ websiteLink:      https://craftcms.com/
 websiteLinkText:  craftcms.com
 category:         CMS
 image:            craft-cms-mark-black-new.svg
-version:          3.5
+version:          3.6
 supportLevel:     a
 
 keywords:

--- a/docs/craft-3-about.md
+++ b/docs/craft-3-about.md
@@ -37,5 +37,5 @@ There are [two hosting stacks](/stacks) here on fortrabbit. You can choose with 
 
 1. **[Install Craft CMS locally](craft-3-install-local)**: Install new with Composer or use an existing project
 2. **[Setup Craft for fortrabbit](/craft-3-setup)**: Prepare environment, set defaults
-3. **[Deploy Craft](/craft-3-deploy-craft-copy)**: Use our Craft Copy tool to deploy your Craft
+3. **[Deploy Craft](/craft-3-deploy-craft-copy)**: Use our Craft Copy tool
 5. **[Tune Craft](/craft-3-tune)**: Master it!

--- a/docs/craft-3-assets-pro.md
+++ b/docs/craft-3-assets-pro.md
@@ -12,7 +12,7 @@ websiteLink:      https://craftcms.com/
 websiteLinkText:  craftcms.com
 category:         CMS
 image:            craft-cms-mark-black-new.svg
-version:          3.5
+version:          3.6
 uniLink:          craft-3-assets-uni
 supportLevel:     a
 

--- a/docs/craft-3-assets-uni.md
+++ b/docs/craft-3-assets-uni.md
@@ -12,7 +12,7 @@ websiteLink:      https://craftcms.com/
 websiteLinkText:  craftcms.com
 category:         CMS
 image:            craft-cms-mark-black-new.svg
-version:          3.5
+version:          3.6
 proLink:          craft-3-assets-pro
 supportLevel:     a
 

--- a/docs/craft-3-deploy-craft-copy.md
+++ b/docs/craft-3-deploy-craft-copy.md
@@ -1,0 +1,71 @@
+---
+
+template:         article
+reviewed:         2020-02-02
+title:            Deploy Craft CMS with Craft Copy
+naviTitle:        Deploy Craft
+lead:             Learn how to deploy Craft CMS code base with Git to fortrabbit. 
+group:            craft
+stack:            all
+
+websiteLink:      https://craftcms.com/
+websiteLinkText:  craftcms.com
+category:         CMS
+image:            craft-cms-mark-black-new.svg
+version:          3.6
+supportLevel:     a
+
+keywords:
+  - craft
+  - craftCMS
+  - setup
+  - install-guide
+
+---
+
+
+
+## Get ready
+
+Make sure to have completed all steps from the [get ready guide](/craft-3-about). You now should have Craft installed in your local development environment already, if not see [here](craft-3-install-local).
+
+
+## About Craft Copy
+
+Craft Copy is a command line tool to help you deploying Craft CMS from our local development environment to your fortrabbit App. It will take care of the code, the assets and the database.
+
+
+## Installing and using Craft Copy
+
+Please see the Craft Copy usage guide at Github [github.com/fortrabbit/craft-copy](https://github.com/fortrabbit/craft-copy#requirements). It guides you through the 
+
+
+## Alternative ways to deploy Craft CMS
+
+Don't feel like using Craft Copy? Np problem! Here are some alternative ways to deploy Craft on fortrabbit:
+
+### SFTP deployment
+
+There is a more basic guide: [Install Craft using SFTP](/craft-3-upload-sftp).
+
+### Git deployment
+
+If you prefer to use Git directly, check out our guide: [Deploy Craft CMS with Git](/craft-3-deploy-git)
+
+
+### Assets management
+
+There are two dedicated guides here to deploy the Craft `assets` folder separately. It depends on your [App's Stack](/craft-3-about#toc-1-1-choose-your-stack): 
+
+* For Universal Apps: [Deploy assets with rsync](/craft-3-assets-uni)
+* For Professional Apps: [Deploy assets to the Object Storage](/craft-3-assets-pro).
+
+
+### Database 
+
+Please see our general [MySQL guide](/mysql) for various ways to how to copy the database from local to remote and the other way around.
+
+
+## Next steps
+
+See our [Craft tuning guide](/craft-3-tune) to truly master Craft on fortrabbit.

--- a/docs/craft-3-deploy-craft-copy.md
+++ b/docs/craft-3-deploy-craft-copy.md
@@ -37,7 +37,7 @@ Craft Copy is a command line tool to help you deploying Craft CMS from our local
 
 ## Installing and using Craft Copy
 
-Please see the Craft Copy usage guide at Github [github.com/fortrabbit/craft-copy](https://github.com/fortrabbit/craft-copy#requirements). It guides you through the 
+Please see the **[Craft Copy usage guide at GitHub](https://github.com/fortrabbit/craft-copy#requirements)**. It guides you through the process of installing the plugin, connecting your App, deploying code, assets and database.
 
 
 ## Alternative ways to deploy Craft CMS

--- a/docs/craft-3-deploy-git.md
+++ b/docs/craft-3-deploy-git.md
@@ -12,7 +12,7 @@ websiteLink:      https://craftcms.com/
 websiteLinkText:  craftcms.com
 category:         CMS
 image:            craft-cms-mark-black-new.svg
-version:          3.5
+version:          3.6
 supportLevel:     a
 
 keywords:

--- a/docs/craft-3-install-local.md
+++ b/docs/craft-3-install-local.md
@@ -13,7 +13,7 @@ websiteLink:      https://craftcms.com/
 websiteLinkText:  craftcms.com
 category:         CMS
 image:            craft-cms-mark-black-new.svg
-version:          3.5
+version:          3.6
 supportLevel:     a
 
 keywords:

--- a/docs/craft-3-setup.md
+++ b/docs/craft-3-setup.md
@@ -1,7 +1,7 @@
 ---
 
 template:         article
-reviewed:         2020-09-02
+reviewed:         2021-02-02
 title:            Setup Craft CMS
 naviTitle:        Setup Craft
 lead:             How to configure Craft CMS to run locally AND on fortrabbit.

--- a/docs/craft-3-setup.md
+++ b/docs/craft-3-setup.md
@@ -62,16 +62,7 @@ Please include the following settings in the settings file located in `config/ge
 
 ```php
 return [
-    // Global settings
-    '*' => [
-        'siteUrl' => App::env('PRIMARY_SITE_URL') ?: '@web',
-    ],
-    // fortrabbit
-    'production' => [
-        'devMode'           => false,
-        'allowAdminChanges' => false,
-        'allowUpdates'      => false,
-    ],
+    'siteUrl' => App::env('PRIMARY_SITE_URL') ?: '@web',
 ];
 ```
 

--- a/docs/craft-3-setup.md
+++ b/docs/craft-3-setup.md
@@ -13,7 +13,7 @@ websiteLink:      https://craftcms.com/
 websiteLinkText:  craftcms.com
 category:         CMS
 image:            craft-cms-mark-black-new.svg
-version:          3.5
+version:          3.6
 supportLevel:     a
 
 

--- a/docs/craft-3-setup.md
+++ b/docs/craft-3-setup.md
@@ -69,20 +69,6 @@ return [
 The file contains other settings as well: keep those. For more details and options, check out our [Craft CMS tuning guide](/craft-3-tune#toc-craft-cms-configuration-details).
 
 
-## Database synchronization
-
-Now, your [local Craft installation](/craft-3-install-local) should already have created a MySQL database with a few tables in it. The fortrabbit database, on the other hand, is still empty. Now, export your local database and import it to the fortrabbit remote. Head over to our [MySQL export & import guide](/mysql#toc-export-amp-import) to learn how to access the database on fortrabbit and export/import tables.
-
-**PRO TIP**: You will probably often synchronize development and production databases. We have developed a handy command line tool: **[Craft Copy](https://github.com/fortrabbit/craft-copy)** to speed that up. It works like this:
-
-```bash
-# Sync database up (local ⟶ fortrabbit)
-$ php craft copy/db/up
-
-# Sync database down (local ⟵ fortrabbit)
-$ php craft copy/db/down
-```
-
 ## Next steps
 
-Craft CMS is configured to run locally and is also ready for fortrabbit. Next you can [deploy it with Git](/craft-3-deploy-git) or [upload it by SFTP](/craft-3-upload-sftp). Don't forget our [Craft tuning guide](/craft-3-tune) afterwards.
+Craft CMS is configured to run locally and is also ready for fortrabbit. Next you can [deploy it with Craft Copy](/craft-3-deploy-craft-copy).  Don't forget our [Craft tuning guide](/craft-3-tune) afterwards.

--- a/docs/craft-3-tune.md
+++ b/docs/craft-3-tune.md
@@ -29,26 +29,6 @@ keywords:
 Make sure to have followed [our guides](/craft-3-about) so far. You should have already [installed Craft locally](craft-3-install-local), [configured](/craft-3-setup) and deployed it your fortrabbit App. This guide helps you with running, tuning and troubleshooting.
 
 
-## Craft CMS configuration details
-
-```php
-return [
-    // Global settings
-    '*' => [
-        'siteUrl' => App::env('PRIMARY_SITE_URL') ?: '@web'
-    ],    
-    // fortrabbit
-    'production' => [
-        'devMode'            => false,
-        'allowUpdates'       => false,
-        'allowAdminChanges'  => false,
-    ],
-];
-```
-
-Above is an example for `config/general.php`. In the actual file, you will find more settings. The ones above might be discussed in the context of hosting. There are some shared settings, as well as some environment specific settings for production (fortrabbit) and development (locally). Here are the details:
-
-
 ### Multi-environment configuration
 
 Craft embraces the idea of storing environment specific configurations in ENV vars. The database config ([config/db.php](https://github.com/craftcms/craft/blob/master/config/db.php)) is a good example of that.
@@ -63,9 +43,16 @@ ENVIRONMENT=dev
 
 ### Domain setup
 
-Your fortrabbit App comes with a predefined App Name and a URL like `{{appname}}.frb.io` — which is good for testing. At some point you will very likely add your own domains. For general information on how to add domains to your fortrabbit App, please see our [domains article](/domains). For Craft CMS be sure to have set your domain's root path to the `/web` folder. 
+Your fortrabbit App comes with a predefined App Name and a URL like `{{appname}}.frb.io` — which is good for testing. At some point you will very likely add your own domains. For general information on how to add domains to your fortrabbit App, please see our [domains article](/domains). For Craft CMS be sure to have set your domain's root path to the `/web` folder.
 
-Craft CMS usually plays well with any domain. The `@web` syntax in your settings and templates is one way to set it up. You can also use environment variables. Using `'siteUrl' => App::env('PRIMARY_SITE_URL') ?: '@web'`, as in the example above, tells Craft CMS to use the `PRIMARY_SITE_URL` ENV var or the `@web` fallback, which is a good default.  Older versions of Craft might use `SITE_URL`.
+Craft CMS usually plays well with any domain. The `@web` syntax in your settings and templates is one way to set it up. You can also use environment variables. Using `'siteUrl' => App::env('PRIMARY_SITE_URL') ?: '@web'`, as in the example above, tells Craft CMS to use the `PRIMARY_SITE_URL` ENV var or the `@web` fallback, which is a good default. Older versions of Craft might use `SITE_URL`.
+
+```php
+return [
+    // Recommended Domain usage for general.php
+    'siteUrl' => App::env('PRIMARY_SITE_URL') ?: '@web'
+];
+```
 
 You can also add multiple domains. From the fortrabbit side, just point them to the App's root path, configure routing and display of contents within Craft CMS and/or use additional [htaccess rules](/htaccess).
 

--- a/docs/craft-3-tune.md
+++ b/docs/craft-3-tune.md
@@ -13,7 +13,7 @@ websiteLink:      https://craftcms.com/
 websiteLinkText:  craftcms.com
 category:         CMS
 image:            craft-cms-mark-black-new.svg
-version:          3.5
+version:          3.6
 supportLevel:     a
 
 keywords:

--- a/docs/craft-3-tune.md
+++ b/docs/craft-3-tune.md
@@ -1,7 +1,7 @@
 ---
 
 template:         article
-reviewed:         2020-09-02
+reviewed:         2021-02-02
 title:            Tune Craft CMS
 naviTitle:        Tune Craft
 lead:             Tips, tricks, best practices and advanced topics on how to run Craft CMS successfully on fortrabbit.

--- a/docs/craft-3-tune.md
+++ b/docs/craft-3-tune.md
@@ -143,9 +143,7 @@ Otherwise you can run into trouble: Imagine you make changes to the database str
 
 ```php
 return [
-    '*' => [
-        'cpTrigger' => 'godmode'
-    ]
+    'cpTrigger' => 'godmode'
 ];
 ```
 

--- a/docs/craft-3-update.md
+++ b/docs/craft-3-update.md
@@ -13,7 +13,7 @@ websiteLink:      https://craftcms.com/
 websiteLinkText:  craftcms.com
 category:         CMS
 image:            craft-cms-mark-black-new.svg
-version:          3.5
+version:          3.6
 supportLevel:     a
 
 keywords:

--- a/docs/craft-3-upload-sftp.md
+++ b/docs/craft-3-upload-sftp.md
@@ -13,7 +13,7 @@ websiteLink:      https://craftcms.com/
 websiteLinkText:  craftcms.com
 category:         CMS
 image:            craft-cms-mark-black-new.svg
-version:          3.5
+version:          3.6
 supportLevel:     a
 
 keywords:


### PR DESCRIPTION
First iteration to feature Craft Copy as the official way to deploy Craft CMS on fortrabbit. See [Trello Ticket](https://trello.com/c/ZiCTJnJa/2133-craft-copy-update-our-help-pages-to-feature-craft-copy-more-prominently) for more background.